### PR TITLE
Add udev rules for radiacode devices

### DIFF
--- a/radiacode.rules
+++ b/radiacode.rules
@@ -1,2 +1,2 @@
 # Radiacode-10X radiation detector
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="f123", ATTRS{manufacturer}=="AngioScan", GROUP="plugdev", MODE="0660"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="f123", ATTRS{manufacturer}=="AngioScan", TAG+="uaccess", MODE="0660"

--- a/radiacode.rules
+++ b/radiacode.rules
@@ -1,0 +1,2 @@
+# Radiacode-10X radiation detector
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="f123", ATTRS{manufacturer}=="AngioScan", GROUP="plugdev", MODE="0660"


### PR DESCRIPTION
This makes the device accessible to users in the "plugdev" group, so that it can be used by non-root users.