### PR TITLE
Add support for filtering by usb serial number

### DIFF
--- a/radiacode/radiacode.py
+++ b/radiacode/radiacode.py
@@ -18,12 +18,17 @@ def spectrum_channel_to_energy(channel_number: int, a0: float, a1: float, a2: fl
 class RadiaCode:
     _connection: Union[Bluetooth, Usb]
 
-    def __init__(self, bluetooth_mac: Optional[str] = None, ignore_firmware_compatibility_check: bool = False):
+    def __init__(
+        self,
+        bluetooth_mac: Optional[str] = None,
+        serial_number: Optional[str] = None,
+        ignore_firmware_compatibility_check: bool = False,
+    ):
         self._seq = 0
         if bluetooth_mac is not None:
             self._connection = Bluetooth(bluetooth_mac)
         else:
-            self._connection = Usb()
+            self._connection = Usb(serial_number=serial_number)
 
         # init
         self.execute(b'\x07\x00', b'\x01\xff\x12\xff')

--- a/radiacode/transports/usb.py
+++ b/radiacode/transports/usb.py
@@ -18,8 +18,16 @@ class MultipleUSBReadFailure(Exception):
 
 
 class Usb:
-    def __init__(self, timeout_ms=3000):
-        self._device = usb.core.find(idVendor=0x483, idProduct=0xF123)
+    def __init__(self, serial_number=None, timeout_ms=3000):
+        _vid = 0x0483
+        _pid = 0xF123
+
+        if serial_number:
+            self._device = usb.core.find(idVendor=_vid, idProduct=_pid, serial_number=serial_number)
+        else:
+            # usb.core.find(..., serial_number=None) will attempt to match against a value of None,
+            # rather than ignoring it as a match condition.
+            self._device = usb.core.find(idVendor=_vid, idProduct=_pid)
         self._timeout_ms = timeout_ms
         if self._device is None:
             raise DeviceNotFound


### PR DESCRIPTION
`rc = radiacode.RadiaCode()` attaches to the first device libusb happens to discover. If you have multiple radiacode devices attached, perhaps one inside and one outside of an enclosure, you can't just do this

```
rc1 = radiacode.RadiaCode()
rc2 = radiacode.RadiaCode()
```

and trust libusb to get it right. Instead, you get an exception: `USBError: [Errno 16] Resource busy`

This diff adds a `serial_number` argument to the RadiaCode USB constructor which will then be used to attach only that device, eg. `rc = radiacode.RadiaCode(serial_number="RC-102-000456")` would attach to "RC-102-000456" even if "RC-103-000123" was found first.

`radiacode.RadiaCode()` still attaches to the first device.

`radiacode.RadiaCode(serial_number="nonexistent")` raises `DeviceNotFound` as expected.

And now you can do this too:
```
rc103 = radiacode.RadiaCode(serial_number="RC-103-000123")
rc102 = radiacode.RadiaCode(serial_number="RC-102-000456")
```