### PR TITLE
Allow `set_device_on` to turn the device on.

### DIFF
--- a/radiacode/radiacode.py
+++ b/radiacode/radiacode.py
@@ -186,7 +186,6 @@ class RadiaCode:
         self.write_request(VSFR.DEVICE_LANG, struct.pack('<I', bool(lang == 'en')))
 
     def set_device_on(self, on: bool):
-        assert not on, 'only False value accepted'
         self.write_request(VSFR.DEVICE_ON, struct.pack('<I', bool(on)))
 
     def set_sound_on(self, on: bool) -> None:


### PR DESCRIPTION
I've tested this with RC-102 and RC-103 (both fw 4.12) over USB and am able to repeatedly turn the device off and on again.