### PR TITLE
Install libglib2 in the runner so bluepy can build for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
         python-version: ['3.11']
     steps:
     - uses: actions/checkout@v3
-
+          
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -28,6 +28,12 @@ jobs:
         poetry run ruff format --check radiacode radiacode-examples
 
     # TODO
+    #
+    # - name: Install OS Packages
+    #   uses: ConorMacBride/install-package@v1
+    #   with:
+    #       apt: libglib2.0-dev # needed for bluepy
+    #
     # - name: Run tests
     #   run: |
     #     poetry run pytest -ra -v


### PR DESCRIPTION
I see that tests are still a `TODO`; when I was setting up tests for my radiacode-tools project it was necessary to install libglib2 so that I could install and use radiacode in the test runner environment. 