### PR TITLE
making bluetooth a little more optional

### DIFF
--- a/radiacode/transports/bluetooth.py
+++ b/radiacode/transports/bluetooth.py
@@ -6,14 +6,19 @@ class DeviceNotFound(Exception):
     pass
 
 
-if platform.system() == 'Darwin':
+_have_bluetooth = True
+try:
+    from bluepy.btle import BTLEDisconnectError, DefaultDelegate, Peripheral
+except ImportError:
+    _have_bluetooth = False
+
+if platform.system() == 'Darwin' or _have_bluetooth is False:
 
     class Bluetooth:
         def __init__(self):
             # Create an empty class if we are on MacOS
             pass
 else:
-    from bluepy.btle import BTLEDisconnectError, DefaultDelegate, Peripheral
     from radiacode.bytes_buffer import BytesBuffer
 
     class Bluetooth(DefaultDelegate):


### PR DESCRIPTION
Ubuntu doesn't seem to have bluepy in the default repos, so allow the import to fail. This also lets me run simple test scripts from inside the source directory since I have python usb support globally installed already.

Feel free to ignore or reject this, I just found it handy