### PR TITLE
Don't crash when alarms are triggered, and make the alarm events useful

### DIFF
--- a/radiacode/bytes_buffer.py
+++ b/radiacode/bytes_buffer.py
@@ -56,7 +56,7 @@ class BytesBuffer:
         """
         sz = struct.calcsize(fmt)
         if self._pos + sz > len(self._data):
-            raise Exception(f'BytesBuffer: {sz} bytes required for {fmt}, but have only {len(self._data) - self._pos}')
+            raise ValueError(f'BytesBuffer: {sz} bytes required for {fmt}, but have only {len(self._data) - self._pos}')
         self._pos += sz
         return struct.unpack_from(fmt, self._data, self._pos - sz)
 

--- a/radiacode/decoders/databuf.py
+++ b/radiacode/decoders/databuf.py
@@ -5,16 +5,17 @@ from radiacode.types import DoseRateDB, Event, RareData, RawData, RealTimeData
 
 
 def decode_VS_DATA_BUF(
-    br: BytesBuffer,
-    base_time: datetime.datetime,
+    br: BytesBuffer, base_time: datetime.datetime, verbose: bool = False
 ) -> list[RealTimeData | DoseRateDB | RareData | RawData | Event]:
     ret: list[RealTimeData | DoseRateDB | RareData | RawData | Event] = []
     next_seq = None
-    while br.size() > 0:
+    while br.size() >= 7:
         seq, eid, gid, ts_offset = br.unpack('<BBBi')
         dt = base_time + datetime.timedelta(milliseconds=ts_offset * 10)
         if next_seq is not None and next_seq != seq:
-            raise Exception(f'seq jump, expect:{next_seq}, got:{seq}')
+            if verbose:
+                print(f'seq jump while processing {eid=} {gid=}, expect:{next_seq}, got:{seq}')
+            continue
 
         next_seq = (seq + 1) % 256
         if eid == 0 and gid == 0:  # GRP_RealTimeData
@@ -95,7 +96,7 @@ def decode_VS_DATA_BUF(
         elif eid == 1 and gid == 3:  # ???
             samples_num, smpl_time_ms = br.unpack('<HI')
             br.unpack(f'<{14 * samples_num}x')  # skip
-        else:
-            raise Exception(f'Uknown eid:{eid} gid:{gid}')
+        elif verbose:
+            raise Exception(f'Unknown eid:{eid} gid:{gid}')
 
     return ret

--- a/radiacode/decoders/databuf.py
+++ b/radiacode/decoders/databuf.py
@@ -96,7 +96,9 @@ def decode_VS_DATA_BUF(
         elif eid == 1 and gid == 3:  # ???
             samples_num, smpl_time_ms = br.unpack('<HI')
             br.unpack(f'<{14 * samples_num}x')  # skip
-        elif not ignore_errors:
-            print(f'Unknown eid:{eid} gid:{gid}')
+        else:
+            if not ignore_errors:
+                print(f'Unknown eid:{eid} gid:{gid}')
+            break
 
     return ret

--- a/radiacode/decoders/databuf.py
+++ b/radiacode/decoders/databuf.py
@@ -1,7 +1,7 @@
 import datetime
 
 from radiacode.bytes_buffer import BytesBuffer
-from radiacode.types import DoseRateDB, Event, RareData, RawData, RealTimeData
+from radiacode.types import DoseRateDB, Event, EventId, RareData, RawData, RealTimeData
 
 
 def decode_VS_DATA_BUF(
@@ -78,7 +78,7 @@ def decode_VS_DATA_BUF(
             ret.append(
                 Event(
                     dt=dt,
-                    event=event,
+                    event=EventId(event),
                     event_param1=event_param1,
                     flags=flags,
                 )

--- a/radiacode/types.py
+++ b/radiacode/types.py
@@ -202,3 +202,19 @@ class CTRL(Enum):
 
     def __int__(self) -> int:
         return self.value
+
+
+class EventId(Enum):
+    TOGGLE_SIGNAL = 3
+    DOSE_RATE_RESET = 4
+    BATTERY_FULL = 7
+    CHARGE_STOP = 8
+    DOSE_RATE_ALARM1 = 9
+    DOSE_RATE_ALARM2 = 10
+    DOSE_ALARM1 = 12
+    DOSE_ALARM2 = 13
+    COUNT_RATE_ALARM1 = 20
+    COUNT_RATE_ALARM2 = 21
+
+    def __int__(self) -> int:
+        return self.value

--- a/radiacode/types.py
+++ b/radiacode/types.py
@@ -206,7 +206,7 @@ class CTRL(Enum):
 
 class EventId(Enum):
     TOGGLE_SIGNAL = 3
-    DOSE_RATE_RESET = 4
+    DOSE_RESET = 4
     BATTERY_FULL = 7
     CHARGE_STOP = 8
     DOSE_RATE_ALARM1 = 9

--- a/radiacode/types.py
+++ b/radiacode/types.py
@@ -83,6 +83,22 @@ class RareData:
     flags: int
 
 
+class EventId(Enum):
+    TOGGLE_SIGNAL = 3
+    DOSE_RESET = 4
+    BATTERY_FULL = 7
+    CHARGE_STOP = 8
+    DOSE_RATE_ALARM1 = 9
+    DOSE_RATE_ALARM2 = 10
+    DOSE_ALARM1 = 12
+    DOSE_ALARM2 = 13
+    COUNT_RATE_ALARM1 = 20
+    COUNT_RATE_ALARM2 = 21
+
+    def __int__(self) -> int:
+        return self.value
+
+
 @dataclass
 class Event:
     """Device event record.
@@ -95,7 +111,7 @@ class Event:
     """
 
     dt: datetime.datetime
-    event: int
+    event: EventId
     event_param1: int
     flags: int
 
@@ -199,22 +215,6 @@ class CTRL(Enum):
     DOSE_ALARM_1 = 1 << 5
     DOSE_ALARM_2 = 1 << 6
     DOSE_OUT_OF_SCALE = 1 << 7
-
-    def __int__(self) -> int:
-        return self.value
-
-
-class EventId(Enum):
-    TOGGLE_SIGNAL = 3
-    DOSE_RESET = 4
-    BATTERY_FULL = 7
-    CHARGE_STOP = 8
-    DOSE_RATE_ALARM1 = 9
-    DOSE_RATE_ALARM2 = 10
-    DOSE_ALARM1 = 12
-    DOSE_ALARM2 = 13
-    COUNT_RATE_ALARM1 = 20
-    COUNT_RATE_ALARM2 = 21
 
     def __int__(self) -> int:
         return self.value


### PR DESCRIPTION
Possible fix for cdump/radiacode#5

At least, I can set level 1 and level 2 alarm thresholds on count rate, dose rate, and total dose that I could trigger with some fairly safe check sources and then trigger them without crashing my test tool. Instead, the appropriate events are generated.

I haven't yet done anything to prettyprint the events, but they are listed in `types.py` for anyone who cares to look.

(even remembered to run `ruff format`)