### PR TITLE
Fix batch_read_vsfrs, and use it to implement alarm level set/get

### DIFF
--- a/radiacode/types.py
+++ b/radiacode/types.py
@@ -139,6 +139,32 @@ class Spectrum:
     counts: list[int]
 
 
+@dataclass
+class AlarmLimits:
+    """Alarm limits
+
+    The count rate may be per second or per minute depending on device
+    configuration. The `count_unit` attribute indicates which.
+
+    Dose rate is in micro-units (Sv or R) per hour.
+
+    Accumulated dos is in micro-units (Sv or R).
+
+    The dose unit may be Roentgen or Sievert depending on device
+    configuration. The `dose_unit` attribute indicates which. There seems
+    to be a fixed 100Sv/R conversion within the device
+    """
+
+    l1_count_rate: float
+    l2_count_rate: float
+    count_unit: str
+    l1_dose_rate: float
+    l2_dose_rate: float
+    l1_dose: float
+    l2_dose: float
+    dose_unit: str
+
+
 class DisplayDirection(Enum):
     AUTO = 0
     RIGHT = 1


### PR DESCRIPTION
The read request should be encoded as int(n)+list[int(vsfr]); telling the device first how many VSFRs you wish to read, followed by their IDs. Incorrect encoding will crash your device.

Then, depending on which VSFRs you read, you might want to decode them as something other than ints. By way of example, you could retrieve the calibration coefficients by hand with

```
resp = rc103.batch_read_vsfrs(
    [VSFR.CHN_TO_keV_A0, VSFR.CHN_TO_keV_A1, VSFR.CHN_TO_keV_A2],
	"<4x3f")
```

Inspecting the result from `execute()`, I get back the following 16 byte response: '07000000f5dbc4c084f51f40bc5ff339'. Without providing a format that would unhelpfully decode to [7, 3234126837, 1075836292, 972251068]

By providing the format string `<4x3f`, that decodes to (-6.15185022354126, 2.4993600845336914, 0.00046419899445027113) which are in fact the calibration coefficients for my device. I get the same values from the `energy_calib()` function, as well as from querying the VSFRs individually.