### PR TITLE
RFC: Embed our knowledge of VSFR types into the batch reader

### DIFF
--- a/radiacode/types.py
+++ b/radiacode/types.py
@@ -174,6 +174,10 @@ class DisplayDirection(Enum):
         return self.value
 
 
+# Conveniently, the radiacode tells us what VSFRs are available and what their
+# data types are. By reading the SFR_FILE (Special Function Register?) string,
+# we get a list of all the SFRs with their address (opcode), their size in bytes,
+# their type (int or float), and whether they're signed or not.
 class VSFR(Enum):
     DEVICE_CTRL = 0x0500
     DEVICE_LANG = 0x0502
@@ -271,6 +275,75 @@ class VSFR(Enum):
 
     def __int__(self) -> int:
         return self.value
+
+
+_VSFR_FORMATS: dict = {
+    VSFR.DEVICE_CTRL: '3xB',
+    VSFR.DEVICE_LANG: '3xB',
+    VSFR.DEVICE_ON: '3x?',
+    VSFR.DEVICE_TIME: 'I',
+    VSFR.BLE_TX_PWR: '3xB',
+    VSFR.DISP_CTRL: '3xB',
+    VSFR.DISP_BRT: '3xB',
+    VSFR.DISP_CONTR: '3xB',
+    VSFR.DISP_OFF_TIME: 'I',
+    VSFR.DISP_ON: '3x?',
+    VSFR.DISP_DIR: '3xB',
+    VSFR.DISP_BACKLT_ON: '3x?',
+    VSFR.SOUND_CTRL: '2xH',
+    VSFR.SOUND_VOL: '3xB',
+    VSFR.SOUND_ON: '3x?',
+    VSFR.VIBRO_CTRL: '3xB',
+    VSFR.VIBRO_ON: '3x?',
+    VSFR.ALARM_MODE: '3xB',
+    VSFR.MS_RUN: '3x?',
+    VSFR.PLAY_SIGNAL: '3xB',
+    VSFR.DR_LEV1_uR_h: 'I',
+    VSFR.DR_LEV2_uR_h: 'I',
+    VSFR.DS_LEV1_100uR: 'I',
+    VSFR.DS_LEV2_100uR: 'I',
+    VSFR.DS_LEV1_uR: 'I',
+    VSFR.DS_LEV2_uR: 'I',
+    VSFR.DS_UNITS: '3x?',
+    VSFR.USE_nSv_h: '3x?',
+    VSFR.CR_UNITS: '3x?',
+    VSFR.CPS_FILTER: '3xB',
+    VSFR.CR_LEV1_cp10s: 'I',
+    VSFR.CR_LEV2_cp10s: 'I',
+    VSFR.DOSE_RESET: '3x?',
+    VSFR.CHN_TO_keV_A0: 'f',
+    VSFR.CHN_TO_keV_A1: 'f',
+    VSFR.CHN_TO_keV_A2: 'f',
+    VSFR.CPS: 'I',
+    VSFR.DR_uR_h: 'I',
+    VSFR.DS_uR: 'I',
+    VSFR.TEMP_degC: 'f',
+    VSFR.RAW_TEMP_degC: 'f',
+    VSFR.TEMP_UP_degC: 'f',
+    VSFR.TEMP_DN_degC: 'f',
+    VSFR.ACC_X: '2xh',
+    VSFR.ACC_Y: '2xh',
+    VSFR.ACC_Z: '2xh',
+    VSFR.OPT: '2xH',
+    VSFR.VBIAS_mV: '2xH',
+    VSFR.COMP_LEV: '2xh',
+    VSFR.CALIB_MODE: '3x?',
+    VSFR.SYS_MCU_ID0: 'I',
+    VSFR.SYS_MCU_ID1: 'I',
+    VSFR.SYS_MCU_ID2: 'I',
+    VSFR.SYS_DEVICE_ID: 'I',
+    VSFR.SYS_SIGNATURE: 'I',
+    VSFR.SYS_RX_SIZE: '2xH',
+    VSFR.SYS_TX_SIZE: '2xH',
+    VSFR.SYS_BOOT_VERSION: 'I',
+    VSFR.SYS_TARGET_VERSION: 'I',
+    VSFR.SYS_STATUS: 'I',
+    VSFR.SYS_MCU_VREF: 'i',
+    VSFR.SYS_MCU_TEMP: 'i',
+    VSFR.DPOT_RDAC: '3xB',
+    VSFR.DPOT_RDAC_EEPROM: '3xB',
+    VSFR.DPOT_TOLER: '3xB',
+}
 
 
 class VS(Enum):


### PR DESCRIPTION
Following on to #48 , I thought I might do some initial work on simplifying the `batch_read_vsfrs()` API. As best I can tell, radiacode transports all VSFRs as uint32le on the wire, no matter how many information-bearing bits they contain: a bool takes 32 bits, just like a float.

Conveniently, the `SFR_FILE` VS tells us which VSFR IDs are defined, and how to interpret them. It is fairly straightforward to parse the output of the `commands()` function which reads the `SFR_FILE` to produce a dict of format strings.

I updated `batch_read_vsfrs()` and its callers to omit the format argument, and just use the lookup dict to figure out what format to use.

As a quick test, the `get_alarm_limits()` function works correctly, as does the hand-rolled equivalent of `energy_calib()`: `rc.batch_read_vsfrs([ CHN_TO_keV_A0, CHN_TO_keV_A1, CHN_TO_keV_A2])`

Thoughs?

PS. here's the trashy script I used to generate the body of the lookup dict...
```python
import iniconfig
import radiacode

cf = iniconfig.IniConfig('', data=radiacode.RadiaCode().commands())

for k in cf.sections:
    v = dict(cf[k].items())
    k = k.removeprefix('RC_').removeprefix('VSFR_')
    c = None
    if v.get('Type', "") == 'float':
        c = 'f'
    else:
        if v.get('Size', False) == '1':
            if v.get('Min', False) == '0' and v.get('Max', False) == '1':
                c = '3x?'
            else:
                c = '3xb' if v.get('Signed', False) == '1' else '3xB'
        elif v.get('Size', False) == '2':
            c = '2xh' if v.get('Signed', False) == '1' else '2xH'
        elif v.get('Size', False) == '4':
            c = 'i' if v.get('Signed', False) == '1' else 'I'

    print(f"\tVSFR.{k}: '{c}',")
```